### PR TITLE
fix: Fix module name in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/pismo/go-money
+module github.com/pismo-foss/go-money
 
 go 1.13


### PR DESCRIPTION
The module name was not the same the repository name, it make inport module
crash with error:
```
declares its path as: github.com/pismo/go-money
but was required as: github.com/pismo-foss/go-money
```
This change make the module name and repository uri the same to fix this problem.